### PR TITLE
Melhorias na função add_asset renomeado os parans e adicionado a capacidade de verificar entre file pointer e file

### DIFF
--- a/opac_ssm_api/client.py
+++ b/opac_ssm_api/client.py
@@ -3,7 +3,6 @@ import os
 import grpc
 import six
 import logging
-from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Itens realizados

 * Alterado a nomeclatura dos parans do add_asset
 * O param file agora se chama **pfile** e aceita **file** e **file pointer** (Python objects)
