### PR TITLE
Garantindo o param metadata como string para o GRPC.

### DIFF
--- a/opac_ssm_api/client.py
+++ b/opac_ssm_api/client.py
@@ -1,7 +1,8 @@
 # coding: utf-8
 import os
-import grpc
 import six
+import grpc
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ class Client(object):
                 file=file_content,
                 filename=filename,
                 type=filetype,
-                metadata=str(metadata)
+                metadata=json.dumps(metadata)
             )
 
             return self.stub.add_asset(asset).id


### PR DESCRIPTION
Esse ajuste em relação com um erro de indexação encontrado no OPAC_SSM: https://github.com/scieloorg/opac_ssm/issues/58